### PR TITLE
Fit Panucci for smaller displays

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -113,7 +113,7 @@ h1 a em {
 }
 @media (max-width: 767px) {
   .panucci {
-    display: none;
+    width: 135px;
   }
 }
 


### PR DESCRIPTION
I felt Panucci was too important a figurehead to hide on smaller displays.  This allows him to stay relevant and unobtrusive.

Image shown is S4

![panucci](https://cloud.githubusercontent.com/assets/3332843/5034541/b0616b12-6b24-11e4-9b81-389bad01096d.jpg)
